### PR TITLE
Errors and Redirects for Empty Searches

### DIFF
--- a/mainsite/catalog/templates/catalog/details.html
+++ b/mainsite/catalog/templates/catalog/details.html
@@ -2,7 +2,9 @@
 {% load static %}
 {% block content %}
 
-
+{% if failed_search %}
+    <!--{% -->
+{% endif %}
 
 {% if item_list %}
 {% for item in item_list %}
@@ -26,12 +28,12 @@
         </div>
         <br> <br>
         <div class="form-group" style="position: relative; bottom: 0px; width: 100%;">
-        
+
 {% if messages %}
     {% for message in messages %}
       <p class="{{ message.tags }}">{{ message }}</p>
     {% endfor %}
-{% endif %}        
+{% endif %}
             <h6>Message {{item.first_name}}:</h6>
             <textarea class="form-control" rows="5" id="message" placeholder="Ask the owner something..." name="message" form="emailform" maxlength="1000" style="border: 1px solid black;"></textarea>
             <div class="row">
@@ -40,7 +42,7 @@
                     <input type="submit" class="btn btn-default" style="background-color: #ffcd00; color: black; width: 100px; border: 1px solid black;" value="Send">
                     </form>
                 </div>
-                
+
                 <div class="col-lg-4">
                     <h6> Owner: {{item.first_name}} </h6>
                 </div>

--- a/mainsite/catalog/templates/catalog/index.html
+++ b/mainsite/catalog/templates/catalog/index.html
@@ -13,14 +13,39 @@
         <button type="button" name="bookButton" class="btn btn-outline-warning" style="width: 80%; margin-bottom: 20px;">Electronics</button>
         <button type="button" name="bookButton" class="btn btn-outline-warning" style="width: 80%; margin-bottom: 20px;">Sporting Goods</button>
         <button type="button" name="bookButton" class="btn btn-outline-warning" style="width: 80%; margin-bottom: 20px;">Educational</button>
-    </div>
+      </div>
+
 
       <!--{% for filter in filters %}
         <a href='\catalog\filter\{{ filter.category_name }}' class='dropdown-item'>{{ filter.category_name }}</a>
-        {% endfor %}-->
+        {% endfor %} <!---->
     </div>
+
+
     <!-- /.col-lg-3 -->
     <div class="col-lg-10 col-md-9 col-sm-8" style="position: static;">
+
+
+      {% if failed_search %}
+        <div style="background-color: black; border: 2px solid black; border-spacing: 10px; text-align: center; margin-bottom: 20px; margin-top: 10px;">
+            <h1 style="color: #ffcd00; margin-top: 3px; margin-bottom: 1.5px;">Oops!</h1>
+            <h6 style="color: #ffcd00; margin-top: 1.5px; margin-bottom: 3px;">
+
+              {% if failed_search == 'FilterFail' %}
+              Looks like no items have been uploaded for that category. But here are some recently-uploaded items instead!
+              {% elif failed_search == 'PageNotFoundFail' %}
+              Looks like that item couldn't be found. But here are some recently-uploaded items instead!
+              {% elif failed_search == 'SearchFail' %}
+              Looks like no items could be found for your search. But here are some recently-uploaded items instead!
+              {% else %}
+              Looks like something went wrong. Please contact MTU HuskyHunt if this error persists.
+              {% endif %}
+
+            </h6>
+        </div>
+      {% endif %}
+      <!-- -->
+
         <div class="row">
             {% if items %}
             {% for item in items %}
@@ -68,7 +93,7 @@
             {% endif %}
         </span>
     </div>
-    
+
     <!-- /.row -->
 </div>
 <!-- /.col-lg-9 -->

--- a/mainsite/catalog/views.py
+++ b/mainsite/catalog/views.py
@@ -7,32 +7,53 @@ from django.contrib import auth
 from django.core.mail import BadHeaderError, send_mail
 from django.contrib import messages
 from django.core.paginator import Paginator
+from django.urls import reverse
+
+
+#This small helper function adds an appropriate error message to the page
+#param: context - the context that's normally passed to the catalog pages;
+#         it's modified appropriately during this function to contain recent items
+#param: type - one of 'SearchFail', 'FilterFail', 'PageNotFoundFail', etc.
+#param: num_pages - The number of recent items displayed, default is 4 most recent
+#returns: boolean whether or not
+def addErrorOnEmpty(context, type, num_pages = 4):
+    context['failed_search'] = None
+    if context['items'].count() == 0:
+        context['failed_search'] = type
+        context['items'] = CatalogItem.objects.order_by('-date_added')[0:num_pages];
+        return True
+    return False
+
 
 #This function takes information from the search textfield
 #param: request - array variable that is passed around the website, kinda like global variables
-#returns: all items in the database that contain the string 
+#returns: all items in the database that contain the string
 #from the search text field in their name or description
 def search(request):
-  #The CSS code for this function can be found here           
-  template = 'catalog/index.html'      
-    #The title for the webpage
-  title = 'MTU Catalog' 
+  #The CSS code for this function can be found here
+  template = 'catalog/index.html'
 
-    #Checks to make sure the user has logged in               
-  if request.user.is_authenticated:    
+    #The title for the webpage
+  title = 'MTU Catalog'
+
+    #Checks to make sure the user has logged in
+  if request.user.is_authenticated:
         #Uses the filter function to get the data of the searched items
     recent_items = CatalogItem.objects.filter(
       Q(item_description__contains=request.GET['search']) | Q(item_title__contains=request.GET['search'])
     )
+
         #Gets all the different categories
     filters = Category.objects.all()
 
         #Puts all the data to be displayed into context
     context = {
-      'item_list': recent_items,
+      'items': recent_items,
       'title': title,
       'filters': filters,
     }
+
+    addErrorOnEmpty(context, 'SearchFail')
 
         #Returns a render function call to display onto the website for the user to see
     return render(request, template, context)
@@ -40,8 +61,9 @@ def search(request):
     #If the user is not logged in then they get redirected to the HuskyStatue screen
   else:
     return HttpResponseRedirect('/')
-  
-#This function gets all the items from the database 
+
+
+#This function gets all the items from the database
 #and displays them to the screen sorted by most recently added
 #param: request - array variable that is passed around the website, kinda like global variables
 #returns: all the items in the database, with the most recently item added at the top
@@ -51,6 +73,11 @@ def index(request):
     template = 'catalog/index.html'
     #The title for the webpage
     title = "MTU Catalog"
+
+    failed_search = None
+    if request.session.has_key('index_redirect_failed_search') and request.session['index_redirect_failed_search'] is not None:
+        failed_search = request.session['index_redirect_failed_search']
+        request.session['index_redirect_failed_search'] = None
 
     #Checks if the user is logged in
     if request.user.is_authenticated:
@@ -72,16 +99,18 @@ def index(request):
 
         #Packages the information to be displayed into context
         context = {
-            'item_list': recent_items, # NOT NEEDED? ----------------------------------------
+            #'item_list': recent_items, # NOT NEEDED? ----------------------------------------
             'title': title,
             'filters': filters,
             'items': items,
+            'failed_search': failed_search,
         }
 
         #Displays all the items from the database with repect to the CSS template
         return render(request, template, context)
     else:
         return HttpResponseRedirect('/')
+
 
 #This function sends a prepared email message to a seller
 #param: request - array variable that is passed around the website, kinda like global variables
@@ -90,18 +119,18 @@ def index(request):
 def email(request, pk):
     #Checks if the user has logged in
     if request.user.is_authenticated:
-        
+
         #The subject line of the email
         subject = "Interested in your item"
-        
+
         #The body of the email
-        message = (request.user.get_short_name() + 
-                  ' has messaged you about an item you posted on HuskyHunt!\n\n' + 
-                  request.user.get_short_name() + ': ' + request.GET['message'] + 
-                  '\n\nReply at: ' + request.user.email + 
-                  '\n*Do not reply to this email. Your reply will be forever ' + 
+        message = (request.user.get_short_name() +
+                  ' has messaged you about an item you posted on HuskyHunt!\n\n' +
+                  request.user.get_short_name() + ': ' + request.GET['message'] +
+                  '\n\nReply at: ' + request.user.email +
+                  '\n*Do not reply to this email. Your reply will be forever ' +
                   'lost in the interweb and your will be sad')
-        
+
         #The email that this message is sent from
         from_email = 'admin@huskyhunt.com'
         #Gets the item that is currently being viewed
@@ -115,7 +144,7 @@ def email(request, pk):
         for item in item_list:
             #Sets the recipient of the email as the sellers email from the database
             to_email = item.username.email
-        
+
         #Checks if the message is no empty
         if (request.GET['message'] != ''):
 
@@ -123,15 +152,15 @@ def email(request, pk):
             send_mail(subject, message, from_email, [to_email], fail_silently=False,)
             #Displays that the email was sent successfully
             messages.error(request, 'Message sent successfully!')
-        
+
         #If the message is empty then an error message is displayed
         else:
             messages.error(request, 'Please enter a message!')
-        
+
         #Redirects the user to the same webpage (So nothing changes but the success message appearing)
         return HttpResponseRedirect('/catalog/' + str(pk))
-    
-    #If not logged in then the user is sent to the Husky Statue 
+
+    #If not logged in then the user is sent to the Husky Statue
     else:
         return HttpResponseRedirect('/')
 
@@ -139,23 +168,29 @@ def email(request, pk):
 #while removing the other item from the view of the user
 #param: request - array variable that is passed around the website, kinda like global variables
 #param: pk - a int variable that is used as the primary key for the item in the database
-#returns: A new page of the website that contains all information on one item 
+#returns: A new page of the website that contains all information on one item
 def detail(request, pk):
 
     #The CSS for this page of the website can be found here
     template = 'catalog/details.html'
-    
+
     #Checks if the user is logged in
     if request.user.is_authenticated:
-        
+
         #Gets the item from the database
         item_list = CatalogItem.objects.filter(pk=pk)
-        
+
         #Packages the information to be displayed into context
         context = {
                 'item_list': item_list,
         }
-    
+
+        if item_list.count() == 0:
+                request.session['index_redirect_failed_search'] = 'PageNotFoundFail'
+                return HttpResponseRedirect(reverse('catalog:index'))
+
+
+
     #Changes what the user sees to be more detailed information on the one item
         return render(request, template, context)
     #If the user is not logged in, redirect to login
@@ -183,14 +218,18 @@ def filter(request, category):
         recent_items = CatalogItem.objects.filter(category__category_name=category)
         #Keeps the filters dropdown containing all the categories (need to get a default category)
         filters = Category.objects.all()
+
         context = {
-            'item_list': recent_items,
+            'items': recent_items,
             'title': title,
             'filters': filters,
         }
+
+        addErrorOnEmpty(context, 'FilterFail')
+
         #Displays the new view with items only in the desired category
         return render(request, template, context)
-    
+
     #If the user is not logged in then they are sent to the Husky Statue
     else:
         return HttpResponseRedirect('/')


### PR DESCRIPTION
Both filters and searches with no matching items will both display an error message and the most recently-uploaded items; trying to access a nonexistent page will redirect to index, again with an error message. The context parameter 'failed_state' has various possible values (None for no error, 'PageNotFoundFail' for nonexistent page, etc.); the corresponding error messages can be customized in the template specification.