### PR TITLE
Add basic readonly REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ collected_static
 mainsite/huskydb
 mainsite/uploads/account/profilepics/*
 mainsite/uploads/catalog/*
+
+# Virtual environment
+venv

--- a/mainsite/accountant/templates/accountant/developer_settings.html
+++ b/mainsite/accountant/templates/accountant/developer_settings.html
@@ -10,14 +10,28 @@
 
     <div class="row">
       <div class="col">
+        <p>
+          There is a REST API (read-only) available at <code>/api</code>.
+        </p>
+
+        <p>
+          Documentation can be found <a href="/api">here</a>.
+        </p>
+
+        <p>
+          All requests require an authorization header to be included:
+        </p>
+
+        <p>
+          <code>Authorization: Token {{current_token}}</code>
+        </p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col">
         <a href="/accountant/developer/token/generate" class="btn {{ current_token|yesno:"btn-danger,btn-primary"}}">{{ current_token|yesno:"Regenerate Token,Generate Token"}}</a>
       </div>
-
-      {% if current_token %}
-        <div class="col*-lg-auto my-auto">
-          <code>{{current_token}}</code>
-        </div>
-      {% endif %}
     </div>
   </div>
 </div>

--- a/mainsite/accountant/templates/accountant/developer_settings.html
+++ b/mainsite/accountant/templates/accountant/developer_settings.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="row justify-content-center">
+  <div class='col*-lg-auto'>
+    <h1>Developer Settings</h1>
+
+    <h3>REST API</h3>
+
+    <div class="row">
+      <div class="col">
+        <a href="/accountant/developer/token/generate" class="btn {{ current_token|yesno:"btn-danger,btn-primary"}}">{{ current_token|yesno:"Regenerate Token,Generate Token"}}</a>
+      </div>
+
+      {% if current_token %}
+        <div class="col*-lg-auto my-auto">
+          <code>{{current_token}}</code>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/mainsite/accountant/templates/accountant/index.html
+++ b/mainsite/accountant/templates/accountant/index.html
@@ -13,6 +13,7 @@
     <div class="row align-items-end">
     <div class="col-lg-auto">
       <a href="{% url 'accountant:edit' %}" method="get" class="btn btn-warning">Edit Account</a>
+      <a href="{% url 'accountant:developer' %}" method="get" class="btn btn-primary">Developer</a>
     </div>
   </div>
 </div>

--- a/mainsite/accountant/urls.py
+++ b/mainsite/accountant/urls.py
@@ -9,6 +9,8 @@ urlpatterns = [
     path('catalog/', views.catalogRedirect, name='authsuccess'),
     path('', views.index, name='index'),
     path('logout/', views.logout, name='logout'),
+    path('developer/', views.developer, name='developer'),
+    path('developer/token/generate', views.developer_generate_token, name='generateToken'),
 
     # used for deleting an item
     path('<int:pk>/', views.deleteItem, name='deleteItem'),

--- a/mainsite/accountant/views.py
+++ b/mainsite/accountant/views.py
@@ -3,6 +3,7 @@ from django.http import HttpResponseRedirect
 from django.contrib import auth
 from catalog.models import CatalogItem, Category, SubCategory
 from rideSharing.models import RideItem
+from rest_framework.authtoken.models import Token
 from django.utils import timezone
 
 from accountant.models import user_profile
@@ -82,6 +83,29 @@ def index(request):
         return render(request, template, context)
     else:
         return HttpResponseRedirect('/')
+
+def developer(request):
+    if request.user.is_authenticated:
+        current_token = Token.objects.filter(user = request.user).first()
+
+        return render(request, 'accountant/developer_settings.html', {
+            'current_token': current_token
+        })
+    else:
+        return HttpResponseRedirect('/')
+
+def developer_generate_token(request):
+    if request.user.is_authenticated:
+        current_token = Token.objects.filter(user = request.user).first()
+
+        if current_token:
+            current_token.delete()
+
+        Token.objects.create(user = request.user)
+
+    else:
+        return HttpResponseRedirect('/')
+    return HttpResponseRedirect('/accountant/developer')
 
 # Used as an intermediate function to delete an item
 def deleteItem(request, pk):

--- a/mainsite/api/serializers.py
+++ b/mainsite/api/serializers.py
@@ -1,0 +1,23 @@
+from django.contrib.auth.models import User
+from catalog.models import Category, SubCategory, CatalogItem
+from rest_framework import serializers
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ['first_name', 'url']
+
+class CategorySerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Category
+        fields = '__all__'
+
+class SubCategorySerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = SubCategory
+        fields = '__all__'
+
+class CatalogItemSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = CatalogItem
+        fields = '__all__'

--- a/mainsite/api/views.py
+++ b/mainsite/api/views.py
@@ -1,0 +1,20 @@
+from django.contrib.auth.models import User
+from rest_framework import viewsets
+from rest_framework import permissions
+from catalog.models import CatalogItem, Category
+from api.serializers import UserSerializer, CatalogItemSerializer, CategorySerializer
+
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+class CatalogItemViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = CatalogItem.objects.all().order_by('-date_added')
+    serializer_class = CatalogItemSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/mainsite/mainsite/settings.py
+++ b/mainsite/mainsite/settings.py
@@ -64,14 +64,24 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_cron',
+    'rest_framework',
+    'rest_framework.authtoken',
     'accountant',
     'catalog',
     'rideSharing',
     'landing',
     'polls',
     'selling',
-    'social_django'
+    'social_django',
 ]
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication'
+    ],
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/mainsite/mainsite/urls.py
+++ b/mainsite/mainsite/urls.py
@@ -17,7 +17,14 @@ from django.contrib import admin
 from django.conf import settings
 from django.urls import include, path
 from django.conf.urls import url, include
+from rest_framework import routers
+from api import views
 from . import comingSoon
+
+router = routers.DefaultRouter()
+router.register(r'users', views.UserViewSet)
+router.register(r'items', views.CatalogItemViewSet)
+router.register(r'categories', views.CategoryViewSet)
 
 urlpatterns = [
     path('accountant/', include('accountant.urls', namespace='accountant')),
@@ -30,6 +37,7 @@ urlpatterns = [
     path('', include('landing.urls', namespace='landing')),
     url(r'^auth/', include('social_django.urls', namespace='social')),  # <- Here
     path('auth/complete/google-oauth2/', include('accountant.urls', namespace='authsuccess')),
+    path('api/', include(router.urls)),
 ]
 
 if settings.SHOW_COMING_SOON:

--- a/mainsite/staticfiles/mainsite/css/base.css
+++ b/mainsite/staticfiles/mainsite/css/base.css
@@ -16,6 +16,10 @@ body {
     background: #1C1C21;
 }
 
+p {
+  color: white;
+}
+
 .top-links a, .my-account a, .logout a{
   color: #FFCD00;
   padding-left: 1rem;

--- a/mainsite/user/models.py
+++ b/mainsite/user/models.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gunicorn
 django-environ
 whitenoise
 mysqlclient
+djangorestframework


### PR DESCRIPTION
Adds a basic readonly REST API for third-party integrations. Generates an authentication token for use with the API upon user creation, and the generated token can be viewed/changed on a new 'developer' page. The new page also contains some simple documentation for the API.

This is the first step towards hopefully adding webhooks.

(Figured I'd get some actual work done so I didn't feel guilty about playing Factorio the rest of the day. 😛)