### PR TITLE
Charles more moderation

### DIFF
--- a/mainsite/accountant/admin.py
+++ b/mainsite/accountant/admin.py
@@ -27,7 +27,8 @@ class user_profileAdmin(admin.ModelAdmin):
 			archiveAllUserPosts(user)
 
 			#The body of the email
-			message = ('Your account on HuskyHunt has been suspended for seven days.\n\n\nThis is an automated message.')
+			message = ('Your account on HuskyHunt has been suspended for seven days.\n'
+				+ 'For more information, contact the HuskyHunt team at huskyhunt-l@mtu.edu\n\nThis is an automated message.')
 
 			#The email that this message is sent from
 			from_email = 'Admin via HuskyHunt <admin@huskyhunt.com>'
@@ -38,7 +39,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		        message, #body
 		        from_email, # from_email
 		        [to_email],  # to email
-		        reply_to=[to_email],  # reply to email
+		        reply_to=['huskyhunt-l@mtu.edu'],  # reply to email
 		        )
 			email.send();
 
@@ -54,7 +55,8 @@ class user_profileAdmin(admin.ModelAdmin):
 			archiveAllUserPosts(user)
 
 			#The body of the email
-			message = ('Your account on HuskyHunt has been suspended for thirty days.\n\n\nThis is an automated message.')
+			message = ('Your account on HuskyHunt has been suspended for thirty days.\n'
+				+ 'For more information, contact the HuskyHunt team at huskyhunt-l@mtu.edu\n\nThis is an automated message.')
 
 			#The email that this message is sent from
 			from_email = 'Admin via HuskyHunt <admin@huskyhunt.com>'
@@ -65,7 +67,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		        message, #body
 		        from_email, # from_email
 		        [to_email],  # to email
-		        reply_to=[to_email],  # reply to email
+		        reply_to=['huskyhunt-l@mtu.edu'],  # reply to email
 		        )
 			email.send();
 
@@ -80,7 +82,8 @@ class user_profileAdmin(admin.ModelAdmin):
 			archiveAllUserPosts(user)
 
 			#The body of the email
-			message = ('Your account on HuskyHunt has been banned.\n\n\nThis is an automated message.')
+			message = ('Your account on HuskyHunt has been banned.\n'
+				+ 'For more information, contact the HuskyHunt team at huskyhunt-l@mtu.edu\n\nThis is an automated message.')
 
 			#The email that this message is sent from
 			from_email = 'Admin via HuskyHunt <admin@huskyhunt.com>'
@@ -91,7 +94,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		        message, #body
 		        from_email, # from_email
 		        [to_email],  # to email
-		        reply_to=[to_email],  # reply to email
+		        reply_to=['huskyhunt-l@mtu.edu'],  # reply to email
 		        )
 			email.send();
 

--- a/mainsite/accountant/admin.py
+++ b/mainsite/accountant/admin.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 import pytz
 from django.core.mail import BadHeaderError, send_mail, EmailMessage
 
-
 @admin.register(user_profile)
 class user_profileAdmin(admin.ModelAdmin):
 	name = 'test'
@@ -86,4 +85,11 @@ class user_profileAdmin(admin.ModelAdmin):
 	timeout_user_seven.short_description = "Timeout 7 Days"
 	timeout_user_thirty.short_description = "Timeout 30 Days"
 	ban_user.short_description = "Ban User"
+
+	def get_actions(self, request):
+		#https://stackoverflow.com/questions/34152261/remove-the-default-delete-action-in-django-admin
+		actions = super().get_actions(request)
+		if 'delete_selected' in actions:
+			del actions['delete_selected']
+		return actions;
 

--- a/mainsite/accountant/admin.py
+++ b/mainsite/accountant/admin.py
@@ -19,7 +19,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		# Send emails
 		for user in queryset:
 			#The body of the email
-			message = ('Your account on HuskyHunt has been suspended for seven days.\n')
+			message = ('Your account on HuskyHunt has been suspended for seven days.\n\n\nThis is an automated message.')
 
 			#The email that this message is sent from
 			from_email = 'Admin via HuskyHunt <admin@huskyhunt.com>'
@@ -30,7 +30,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		        message, #body
 		        from_email, # from_email
 		        [to_email],  # to email
-		        reply_to=[],  # reply to email
+		        reply_to=[to_email],  # reply to email
 		        )
 			email.send();
 
@@ -44,7 +44,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		# Send emails
 		for user in queryset:
 			#The body of the email
-			message = ('Your account on HuskyHunt has been suspended for thirty days.\n')
+			message = ('Your account on HuskyHunt has been suspended for thirty days.\n\n\nThis is an automated message.')
 
 			#The email that this message is sent from
 			from_email = 'Admin via HuskyHunt <admin@huskyhunt.com>'
@@ -55,7 +55,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		        message, #body
 		        from_email, # from_email
 		        [to_email],  # to email
-		        reply_to=[],  # reply to email
+		        reply_to=[to_email],  # reply to email
 		        )
 			email.send();
 
@@ -68,7 +68,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		# Send emails
 		for user in queryset:
 			#The body of the email
-			message = ('Your account on HuskyHunt has been banned.\n')
+			message = ('Your account on HuskyHunt has been banned.\n\n\nThis is an automated message.')
 
 			#The email that this message is sent from
 			from_email = 'Admin via HuskyHunt <admin@huskyhunt.com>'
@@ -79,7 +79,7 @@ class user_profileAdmin(admin.ModelAdmin):
 		        message, #body
 		        from_email, # from_email
 		        [to_email],  # to email
-		        reply_to=[],  # reply to email
+		        reply_to=[to_email],  # reply to email
 		        )
 			email.send();
 

--- a/mainsite/accountant/admin.py
+++ b/mainsite/accountant/admin.py
@@ -3,6 +3,13 @@ from accountant.models import user_profile
 from datetime import datetime, timedelta
 import pytz
 from django.core.mail import BadHeaderError, send_mail, EmailMessage
+from catalog.models import CatalogItem
+
+def archiveAllUserPosts(user):
+	items = CatalogItem.objects.filter(archived='False', username=user.user)
+	for item in items:
+		item.archived=True
+		item.save()
 
 @admin.register(user_profile)
 class user_profileAdmin(admin.ModelAdmin):
@@ -17,6 +24,8 @@ class user_profileAdmin(admin.ModelAdmin):
 
 		# Send emails
 		for user in queryset:
+			archiveAllUserPosts(user)
+
 			#The body of the email
 			message = ('Your account on HuskyHunt has been suspended for seven days.\n\n\nThis is an automated message.')
 
@@ -42,6 +51,8 @@ class user_profileAdmin(admin.ModelAdmin):
 
 		# Send emails
 		for user in queryset:
+			archiveAllUserPosts(user)
+
 			#The body of the email
 			message = ('Your account on HuskyHunt has been suspended for thirty days.\n\n\nThis is an automated message.')
 
@@ -66,6 +77,8 @@ class user_profileAdmin(admin.ModelAdmin):
 
 		# Send emails
 		for user in queryset:
+			archiveAllUserPosts(user)
+
 			#The body of the email
 			message = ('Your account on HuskyHunt has been banned.\n\n\nThis is an automated message.')
 

--- a/mainsite/accountant/views.py
+++ b/mainsite/accountant/views.py
@@ -50,7 +50,7 @@ class EditModelForm( ProfFiltered_ModelForm ):
 
     def clean_picture(self):
         pic = self.cleaned_data['picture']
-        if pic.size > settings.MAX_UPLOAD_SIZE:
+        if (pic != None and pic.size > settings.MAX_UPLOAD_SIZE):
             raise forms.ValidationError(_('Filesize is too large and image could not be automatically downsized: Please use a smaller or lower-resolution image. Maximum file size is: %(max_size).1f %(type)s'),
             params={'max_size': 1024**(math.log(settings.MAX_UPLOAD_SIZE, 1024)%1), 'type': ["B", "KB", "MB", "GB", "TB"][int(math.floor(math.log(settings.MAX_UPLOAD_SIZE, 1024)))] }, code='toolarge')
         return pic

--- a/mainsite/catalog/views.py
+++ b/mainsite/catalog/views.py
@@ -221,9 +221,12 @@ def email_functionality(request, pk, item, article, shortdesc, extra_tags):
 
     MAX_EMAIL_COUNT = 10 # 5 seemed too little if you're buying and trying to coordinate rides
 
-    # Gets the preferred name if not empty
+    # Gets the preferred name if not empty, or called 'admin', 'administrator'
     profile = user_profile.objects.filter(user = request.user)
-    if (profile[0].preferred_name):
+    if (profile[0].preferred_name
+        and profile[0].preferred_name.lower() != 'admin'
+        and profile[0].preferred_name.lower() != 'administrator'):
+
         name = profile[0].preferred_name
 
     user_email = request.user.email


### PR DESCRIPTION
- Messages from the admin for a suspension say "This is an automated message"
- Set reply-to email for a suspension to the emailed user (this will be updated if we get a list from MTU for moderators)
- When a user tries to email another with a preferred name of "admin" or "administrator", it uses their first name instead
- Added a null check so preferred names can be set without uploading a picture
- Removed the admin option to delete user profiles
- When a user is suspended, all of their items are archived