### PR TITLE
Fix command that doesn't exist

### DIFF
--- a/on-deploy.sh
+++ b/on-deploy.sh
@@ -4,9 +4,6 @@
 python3 mainsite/manage.py migrate
 python3 mainsite/manage.py migrate django_cron
 
-# Add cron jobs
-python3 mainsite/manage.py crontab add
-
 if [ "$DEBUG" = 'true' ]
 then
   # Also install fixtures


### PR DESCRIPTION
The command to run Django cron jobs is currently present in the system crontab, so they should run.

This just removes a command that fails during deployment (because it doesn't exist).