### PR TITLE
Admin catalog updates, max number of catalog items warning is back

### DIFF
--- a/mainsite/catalog/admin.py
+++ b/mainsite/catalog/admin.py
@@ -21,7 +21,7 @@ class CatalogItemAdmin(admin.ModelAdmin):
     list_display = ('reported', 'archived', 'archivedType', 'pk', 'date_added', 'username', 'item_price', 'item_title', 'item_description')
     list_filter = ['reported', 'archived', 'category', 'date_added', 'username']
     search_fields = ['item_title', 'item_description']
-    actions = ['remove_post', 'allow_post', 'ignore_post', ]
+    actions = ['remove_post', 'allow_post', 'ignore_post', 'delete_post']
 
     def remove_post(self, request, queryset):
         queryset.update(reported=True)
@@ -35,11 +35,21 @@ class CatalogItemAdmin(admin.ModelAdmin):
 
     remove_post.short_description = "Remove offending posts (reported=True, archived=True, type=Removed)"
 
+    def delete_post(self, request, queryset):
+        queryset.update(archived=True)
+        queryset.update(archivedType=ArchivedType.Types.ARCHIVED)
+        # Decrement number of points by three
+        for item in queryset:
+            profile = user_profile.objects.get(user = item.username)
+            profile.points = profile.points - 3
+            profile.save()
+    delete_post.short_description = "Delete posts (archived=True, type=archived)"
+
     def allow_post(self, request, queryset):
         queryset.update(reported=False)
         queryset.update(archived=False)
         queryset.update(archivedType=ArchivedType.Types.VISIBLE)
-    allow_post.short_description = "Unarchive: mark acceptable (reported=True, archived=False, type=visble)"
+    allow_post.short_description = "Unarchive: mark acceptabel (reported=False, archived=False, type=visble)"
 
     def ignore_post(self, request, queryset):
         queryset.update(reported=False)

--- a/mainsite/catalog/admin.py
+++ b/mainsite/catalog/admin.py
@@ -24,7 +24,7 @@ class CatalogItemAdmin(admin.ModelAdmin):
     actions = ['remove_post', 'allow_post', 'ignore_post', ]
 
     def remove_post(self, request, queryset):
-        queryset.update(reported=False)
+        queryset.update(reported=True)
         queryset.update(archived=True)
         queryset.update(archivedType=ArchivedType.Types.REMOVED)
         # Decrement number of points by three
@@ -33,17 +33,17 @@ class CatalogItemAdmin(admin.ModelAdmin):
             profile.points = profile.points - 3
             profile.save()
 
-    remove_post.short_description = "Remove offending posts"
+    remove_post.short_description = "Remove offending posts (reported=True, archived=True, type=Removed)"
 
     def allow_post(self, request, queryset):
         queryset.update(reported=False)
         queryset.update(archived=False)
         queryset.update(archivedType=ArchivedType.Types.VISIBLE)
-    allow_post.short_description = "Unarchive: mark acceptable"
+    allow_post.short_description = "Unarchive: mark acceptable (reported=True, archived=False, type=visble)"
 
     def ignore_post(self, request, queryset):
         queryset.update(reported=False)
-    ignore_post.short_description = "Ignore report (don't use this, unarchive instead)"
+    ignore_post.short_description = "Ignore report (reported=False)"
 
     def get_actions(self, request):
         #https://stackoverflow.com/questions/34152261/remove-the-default-delete-action-in-django-admin

--- a/mainsite/catalog/admin.py
+++ b/mainsite/catalog/admin.py
@@ -49,7 +49,7 @@ class CatalogItemAdmin(admin.ModelAdmin):
         queryset.update(reported=False)
         queryset.update(archived=False)
         queryset.update(archivedType=ArchivedType.Types.VISIBLE)
-    allow_post.short_description = "Unarchive: mark acceptabel (reported=False, archived=False, type=visble)"
+    allow_post.short_description = "Make public (reported=False, archived=False, type=visble)"
 
     def ignore_post(self, request, queryset):
         queryset.update(reported=False)

--- a/mainsite/catalog/templates/catalog/update_actual_content.html
+++ b/mainsite/catalog/templates/catalog/update_actual_content.html
@@ -9,6 +9,15 @@
          <div class='col-lg-5' style='margin: 10px;'>
             <!-- Catalog Form Errors -->
 
+            {% if too_many_items %}
+              <div class="alert alert-danger" role="alert">
+                <strong>You have reached the limit of 10 active items!<br></strong>
+              </div>
+            {% endif %}
+
+            {% if not too_many_items %}
+
+
             <form role="form" method="post" enctype="multipart/form-data" style='border: 2xp;' onsubmit="return ItemInputSubmit() && submitInterceptor();">
                 {% csrf_token %}
 
@@ -26,6 +35,8 @@
                 <hr size="4" >
                 <button type="submit" class="btn btn-primary husky-button-light" id="btnRealButton">Submit</button>
             </form>
+
+            {% endif %}
 
             <!-- General Form Formatting -->
             {% for field in catalog_form %}
@@ -59,6 +70,8 @@
          </div>
      </div>
    </div>
+
+
 
 <!-- Used to prevent multiple submits -->
 <script type="text/javascript">


### PR DESCRIPTION
- Clarified the description of what each admin action does
- Added an option for an admin to delete a post (we didn't want the default delete behavior since that would completely remove items from the database, so this is a custom delete behavior)
- Found that the check for if a page had too many items was removed